### PR TITLE
add alertmanager and cadvisor

### DIFF
--- a/alertmanager/config.tmpl.yml
+++ b/alertmanager/config.tmpl.yml
@@ -1,0 +1,10 @@
+route:
+  group_by: ["alertname"]
+  group_wait: 10s
+  receiver: "telepush"
+
+receivers:
+  - name: "telepush"
+    webhook_configs:
+      - url: "https://telepush.dev/api/inlets/alertmanager/${TELEPUSH_TOKEN}"
+        http_config:

--- a/example.env
+++ b/example.env
@@ -40,3 +40,7 @@ PROMETHEUS_PASSWORD=password
 # Enter your grafana domain
 GRAFANA_DOMAIN=grafana.sld.tld
 
+# ALERTMANAGER ENV
+# Enter your alertmanager domain
+ALERTMANAGER_DOMAIN=alertmanager.sld.tld
+TELEPUSH_TOKEN=yourtoken

--- a/graph-node.tmpl.yml
+++ b/graph-node.tmpl.yml
@@ -163,6 +163,31 @@ services:
       - default
       - monitor
 
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:rw
+      - /sys:/sys:ro
+      - /var/lib/docker:/var/lib/docker:ro
+      # - /cgroup:/cgroup:ro
+    networks:
+      - default
+      - monitor
+    deploy:
+      mode: replicated
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+      placement:
+        constraints:
+          - node.hostname == indexer-${CHAIN_0_NAME}
+      resources:
+        limits:
+          memory: 128M
+        reservations:
+          memory: 64M
+
 networks:
   default:
     name: indexer_${CHAIN_0_NAME}_default

--- a/init-phase0-manager.sh
+++ b/init-phase0-manager.sh
@@ -41,6 +41,8 @@ set -o allexport; source .env; TRAEFIK_HASHED_PASSWORD=${TRAEFIK_HASHED_PASSWORD
 (echo -e "version: '3.8'"; docker compose -f swarmpit.yml --env-file .env config) > deployment/swarmpit.yml
 sed -i -e '2d' deployment/swarmpit.yml
 
+set -o allexport; source .env; envsubst < alertmanager/config.tmpl.yml > alertmanager/config.yml;
+
 echo "deploy traefik/swarmpit"
 docker stack deploy -c deployment/traefik.yml traefik
 docker stack deploy -c deployment/swarmpit.yml swarmpit

--- a/monitor.yml
+++ b/monitor.yml
@@ -13,6 +13,7 @@ services:
       - "--storage.tsdb.path=/prometheus"
     volumes:
       - ../data/prometheus:/prometheus
+      - ../prometheus/alert-rules.yml:/etc/prometheus/alert-rules.yml
     # Swarm
     networks:
       - default
@@ -87,6 +88,42 @@ services:
         - traefik.http.routers.monitor-grafana-https.tls=true
         - traefik.http.routers.monitor-grafana-https.tls.certresolver=le
         - traefik.http.services.monitor-grafana.loadbalancer.server.port=3000
+
+  alertmanager:
+    image: prom/alertmanager
+    user: $USER_ID:$GROUP_ID
+    command:
+      - "--config.file=/etc/alertmanager/config.yml"
+      - "--storage.path=/alertmanager"
+    volumes:
+      - ../alertmanager:/etc/alertmanager
+    networks:
+      - default
+      - monitor
+      - traefik-public
+    deploy:
+      mode: replicated
+      replicas: 1
+      placement:
+        constraints:
+          - node.role == manager
+      resources:
+        limits:
+          memory: 128M
+        reservations:
+          memory: 64M
+      labels:
+        - traefik.enable=true
+        - traefik.docker.network=traefik-public
+        - traefik.constraint-label=traefik-public
+        - "traefik.http.routers.monitor-alertmanager-http.rule=Host(`${ALERTMANAGER_DOMAIN}`)"
+        - traefik.http.routers.monitor-alertmanager-http.entrypoints=http
+        - traefik.http.routers.monitor-alertmanager-http.middlewares=https-redirect
+        - "traefik.http.routers.monitor-alertmanager-https.rule=Host(`${ALERTMANAGER_DOMAIN}`)"
+        - traefik.http.routers.monitor-alertmanager-https.entrypoints=https
+        - traefik.http.routers.monitor-alertmanager-https.tls=true
+        - traefik.http.routers.monitor-alertmanager-https.tls.certresolver=le
+        - traefik.http.services.monitor-alertmanager.loadbalancer.server.port=9093
 
 networks:
   default:

--- a/prometheus/alert-rules.yml
+++ b/prometheus/alert-rules.yml
@@ -1,0 +1,40 @@
+groups:
+  - name: targets
+    rules:
+      - alert: monitor_service_down
+        expr: up == 0
+        for: 30s
+        labels:
+          severity: critical
+        annotations:
+          summary: "Monitor service non-operational"
+          description: "Service {{ $labels.instance }} is down."
+
+  - name: containers
+    rules:
+      - alert: querynode_down
+        expr: absent((time() - container_last_seen{container_label_com_docker_swarm_service_name="indexer-gnosis_index-node"}) < 30)
+        for: 30s
+        labels:
+          severity: critical
+        annotations:
+          summary: "Query Node down"
+          description: "Query Node container is down for more than 30 seconds."
+
+      - alert: indexnode_down
+        expr: absent((time() - container_last_seen{container_label_com_docker_swarm_service_name="indexer-gnosis_query-node"}) < 30)
+        for: 30s
+        labels:
+          severity: critical
+        annotations:
+          summary: "Index Node down"
+          description: "Index Node container is down for more than 30 seconds."
+
+      - alert: postgres_down
+        expr: absent((time() - container_last_seen{container_label_com_docker_swarm_service_name="indexer-gnosis_postgres"}) < 30)
+        for: 30s
+        labels:
+          severity: critical
+        annotations:
+          summary: "Postgres down"
+          description: "Postgres container is down for more than 30 seconds."

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -3,11 +3,21 @@ global:
   evaluation_interval: 15s
 
 rule_files:
+  - "alert-rules.yml"
 
 alerting:
+  alertmanagers:
+    - scheme: http
+      static_configs:
+        - targets:
+            - "alertmanager:9093"
 
 scrape_configs:
   - job_name: "graph-node-gnosis"
     static_configs:
       - targets:
           ["indexer-gnosis_index-node:8040", "indexer-gnosis_query-node:8040"]
+
+  - job_name: "cadvisor"
+    static_configs:
+      - targets: ["cadvisor:8080"]


### PR DESCRIPTION
[StakeSquid](https://github.com/StakeSquid/graphprotocol-testnet-docker)のレポを参考に、alertmanagerとcadvisorを入れました

**Alertmanager**

- アラートメッセージは[telepush](https://telepush.dev/)を利用してtelegramに送信するように設定
- アラートルールの設定はひとまず最低限にしています

**cAdvisor**
container監視用に追加（managerではなくindexer-nodeに追加する必要）


Prometheus
![Screen Shot 2022-10-06 at 15 29 28](https://user-images.githubusercontent.com/1056248/194294875-c2c64882-529d-45bc-a682-77ed6a99d3b1.png)

telegramアラート受信サンプル
![Screen Shot 2022-10-06 at 19 54 01](https://user-images.githubusercontent.com/1056248/194295494-c541b8b4-86d0-4cf0-b6bc-6c3a9eb08eb9.png)

