### PR TITLE
enable traefik metrics and export to prometheus

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -11,3 +11,8 @@ scrape_configs:
     static_configs:
       - targets:
           ["indexer-gnosis_index-node:8040", "indexer-gnosis_query-node:8040"]
+
+  - job_name: "traefik"
+    static_configs:
+      - targets:
+          - "traefik:8080"

--- a/traefik.yml
+++ b/traefik.yml
@@ -78,6 +78,8 @@ services:
       - --log
       # Enable the Dashboard and API
       - --api
+      # Enable Metrics
+      - --metrics.prometheus
     networks:
       # Use the public network created to be shared between Traefik and
       # any other service that needs to be publicly available with HTTPS


### PR DESCRIPTION
主にTheGraphのテストチームからのquery-nodeへのアクセス確認のために、traefikのmetricsをONにし、prometheusに取り込むようにしました

prometheus画面
![Screen Shot 2022-10-07 at 19 43 13](https://user-images.githubusercontent.com/1056248/194535629-771881dd-fd1e-4b7d-8012-2f27d2ff5775.png)
